### PR TITLE
Fixed to work asciidoc format tags for src/KiCad

### DIFF
--- a/src/KiCad/po/ja.po
+++ b/src/KiCad/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: KiCad-ja\n"
 "POT-Creation-Date: 2015-06-23 00:44+0900\n"
-"PO-Revision-Date: 2015-06-27 18:14+0900\n"
+"PO-Revision-Date: 2015-06-29 08:00+0900\n"
 "Last-Translator: yoneken <yoneken@kicad.jp>\n"
 "Language-Team: kicad.jp <kicad@kicad.jp>\n"
 "Language: ja\n"
@@ -49,10 +49,10 @@ msgid ""
 "org/licenses/by/3.0/), version 3.0 or later."
 msgstr ""
 "このドキュメントは以下の貢献者により著作権所有(© 2015)されています。GNU "
-"General Public License ( http://www.gnu.org/licenses/gpl.html ) のバージョン3以"
-"降、あるいはクリエイティブ・コモンズライセンス ( http://creativecommons.org/"
-"licenses/by/3.0/ ) のバージョン3以降のいずれかの条件の下で、配布または変更する"
-"ことができます 。"
+"General Public License ( http://www.gnu.org/licenses/gpl.html ) のバージョン3"
+"以降、あるいはクリエイティブ・コモンズライセンス ( http://creativecommons."
+"org/licenses/by/3.0/ ) のバージョン3以降のいずれかの条件の下で、配布または変"
+"更することができます 。"
 
 #. type: Plain text
 #: KiCad.adoc:23
@@ -340,7 +340,7 @@ msgid ""
 "by the board or the footprint editor or CvPcb.\n"
 msgstr ""
 "|*.kicad_pcb |ページレイアウト以外のすべての基板情報を含むファイル。\n"
-"|*.pretty |フットプリント **ライブラリ・フォルダ**。フォルダ自体がライブラリになっています。\n"
+"|*.pretty |フットプリント **ライブラリ・フォルダ** 。フォルダ自体がライブラリになっています。\n"
 "|*.kicad_mod |説明を含んだフットプリント・ファイル。各ファイルにフットプリントが1つ。\n"
 "|*.brd |古いフォーマットの基板ファイル。\n"
 "基板エディタで読み込みは可能ですが、書き込みはできません。\n"
@@ -486,7 +486,7 @@ msgstr ""
 msgid ""
 "*The default file _kicad.pro_ can be freely modified if necessary,\n"
 "mainly to set the list of libraries files loaded by Eeschema.*\n"
-msgstr "*デフォルトファイルの _kicad.pro_  は、Eeschemaがロードするライブラリファイルのリストを設定するなど必要であれば自由に変更できます。*\n"
+msgstr "*デフォルトファイルの _kicad.pro_ は、Eeschemaがロードするライブラリファイルのリストを設定するなど必要であれば自由に変更できます。*\n"
 
 #. type: Plain text
 #: KiCad.adoc:199
@@ -592,9 +592,9 @@ msgid ""
 "few environment variables are internally defined by Kicad, and can be used "
 "to define paths (for libraries, 3D shapes, etc)."
 msgstr ""
-"Kicadでは、_環境変数_を使ってパスの設定をすることができます。いくつかの環境変"
-"数はKicad自身によって内部で設定され、使用するライブラリや3Dシェイプなどの場所"
-"を指定するために使われます。"
+"Kicadでは、 _環境変数_ を使ってパスの設定をすることができます。いくつかの環境"
+"変数はKicad自身によって内部で設定され、使用するライブラリや3Dシェイプなどの場"
+"所を指定するために使われます。"
 
 #. type: Plain text
 #: KiCad.adoc:241
@@ -603,7 +603,7 @@ msgid ""
 "This is the case for ``official'' libraries built for kicad:"
 msgstr ""
 "これは絶対パスを変更できるようにするなど事前に決められない場合に便利です。例"
-"えばkicadの``公式''ライブラリがそうです。"
+"えばkicadの ``公式'' ライブラリがそうです。"
 
 #. type: Plain text
 #: KiCad.adoc:243
@@ -622,8 +622,8 @@ msgid ""
 "like this, when using the KISYSMOD environment variable to define the full "
 "path: ${KISYSMOD}/connect.pretty"
 msgstr ""
-"例えばフットプリント・ライブラリ_connect.pretty_のフルパスを環境変数KISYSMOD"
-"を使って定義すると次のようになります: ${KISYSMOD}/connect.pretty"
+"例えばフットプリント・ライブラリ _connect.pretty_ のフルパスを環境変数"
+"KISYSMODを使って定義すると次のようになります: ${KISYSMOD}/connect.pretty"
 
 #. type: Plain text
 #: KiCad.adoc:252
@@ -693,9 +693,9 @@ msgid ""
 "pretty_* folder (the pretty footprint library) found **_inside the current "
 "project folder_**."
 msgstr ""
-"例えば*_$\\{KIPRJMOD\\}/connect.pretty_*だったとすると、prettyフットプリン"
-"ト・ライブラリの*_connect.pretty_*フォルダは現在のプロジェクトフォルダ内にあ"
-"ります。"
+"例えば *_$\\{KIPRJMOD\\}/connect.pretty_* だったとすると、prettyフットプリン"
+"ト・ライブラリの *_connect.pretty_* フォルダは **_現在のプロジェクトフォルダ"
+"内に_** あります。"
 
 #. type: Plain text
 #: KiCad.adoc:280
@@ -742,9 +742,9 @@ msgid ""
 "Your can use the default PDF viewer or a PDF viewer Select _Favourite PDF "
 "Viewer_ chosen by _SetPDF Viewer_ menu."
 msgstr ""
-"デフォルトのPDFビューアまたは_PDFビューア設定_メニューで設定したPDFビューアを"
-"使用できます。メニューで設定したPDFビューアを使用する場合は、_お気に入りのPDF"
-"ビューア_を選択します。"
+"デフォルトのPDFビューアまたは _PDFビューア設定_ メニューで設定したPDFビューア"
+"を使用できます。メニューで設定したPDFビューアを使用する場合は、 _お気に入りの"
+"PDFビューア_ を選択します。"
 
 #. type: Plain text
 #: KiCad.adoc:299
@@ -753,8 +753,8 @@ msgid ""
 "_Favourite PDF Viewer_ after selecting a suitable PDF viewer is mandatory."
 msgstr ""
 "LinuxではデフォルトのPDFビューアでは正しく表示できないないことがあります。そ"
-"のため正しく表示できる別のPDFビューアを設定しておき、_お気に入りのPDFビューア"
-"_を選択することが必要です。"
+"のため正しく表示できる別のPDFビューアを設定しておき、 _お気に入りのPDFビュー"
+"ア_ を選択する必要必要があります。"
 
 #. type: Title ~
 #: KiCad.adoc:302
@@ -800,7 +800,8 @@ msgid ""
 "It is _strongly_ recommended to use the same name for both project file and "
 "its directory."
 msgstr ""
-"プロジェクトファイルとそのディレクトリ名を同じにすることを_強く推奨_します。"
+"プロジェクトファイルとそのディレクトリ名を同じにすることを _強く推奨_ しま"
+"す。"
 
 #. type: Plain text
 #: KiCad.adoc:326
@@ -815,8 +816,8 @@ msgstr ""
 "Kicad は、プロジェクト管理のための多くのパラメータ(回路図で使用されるライブラ"
 "リのリストなど )が記録されている拡張子が .pro というファイルを作成します。プ"
 "ロジェクトの名前は、メインの回路図ファイル名、PCB アートワークのファイル名に"
-"使用されます。例えば_example.pro_というプロジェクトが_example_ディレクトリに"
-"作成されたとすると、デフォルトのファイル名は次のようになります:"
+"使用されます。例えば _example.pro_ というプロジェクトが _example_ ディレクト"
+"リに作成されたとすると、デフォルトのファイル名は次のようになります:"
 
 #. type: delimited block |
 #: KiCad.adoc:337
@@ -881,9 +882,9 @@ msgid ""
 "(When these tools are run in _stand alone_ mode, you can open any file in "
 "any project but cross probing between tools can give strange results)"
 msgstr ""
-"(これらのツールを_スタンドアローン_モードで実行すると、プロジェクトに関係なく"
-"すべてのファイルを開くことができます。しかしツール間での連携は正しく機能しま"
-"せん。)"
+"(これらのツールを _スタンドアローン_ モードで実行すると、プロジェクトに関係な"
+"くすべてのファイルを開くことができます。しかしツール間での連携は正しく機能し"
+"ません。)"
 
 #. type: Title ~
 #: KiCad.adoc:357
@@ -1324,7 +1325,7 @@ msgid ""
 "earlier) and any files that match the string replacement rules will be\n"
 "renamed to reflect the new project's name.\n"
 msgstr ""
-"*テンプレートからプロジェクト作成*　テンプレート選択ダイアログが開きます。\n"
+"*テンプレートからプロジェクト作成* テンプレート選択ダイアログが開きます。\n"
 "テンプレート選択ダイアログには、アイコン一覧と表示用ウィンドウがあります。\n"
 "左側のテンプレート・アイコンをクリックするとテンプレートのinfo.htmlメタ\n"
 "データファイルがロードされ、その内容がウィンドウに表示されます。OKボタンを\n"
@@ -1374,7 +1375,7 @@ msgstr "ユーザテンプレート:"
 #: KiCad.adoc:568
 #, no-wrap
 msgid "** on Unix:\n"
-msgstr "**Unixの場合:\n"
+msgstr "** Unixの場合:\n"
 
 #. type: Plain text
 #: KiCad.adoc:569
@@ -1386,7 +1387,7 @@ msgstr "~/kicad/templates/\n"
 #: KiCad.adoc:571
 #, no-wrap
 msgid "** on Windows:\n"
-msgstr "**Windowsの場合:\n"
+msgstr "** Windowsの場合:\n"
 
 #. type: Plain text
 #: KiCad.adoc:572
@@ -1398,7 +1399,7 @@ msgstr "C:\\Documents and Settings\\username\\My Documents\\kicad\\templates\n"
 #: KiCad.adoc:574
 #, no-wrap
 msgid "** on Mac:\n"
-msgstr "**Macの場合:\n"
+msgstr "** Macの場合:\n"
 
 #. type: Plain text
 #: KiCad.adoc:575


### PR DESCRIPTION
メーリングリストで指摘のあった日本語とasciidocフォーマットタグ問題に対応するように修正を加えました。

また文頭に・を置く**も修正しました。