### PR TITLE
Pcbnew/po/ja.po fix image links.

### DIFF
--- a/src/Pcbnew/po/ja.po
+++ b/src/Pcbnew/po/ja.po
@@ -3,8 +3,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pcbnew\n"
 "POT-Creation-Date: 2015-07-05 11:48+0900\n"
-"PO-Revision-Date: 2015-07-07 09:02+0900\n"
-"Last-Translator: starfort <starfort@nifty.com>\n"
+"PO-Revision-Date: 2015-07-08 03:27+0900\n"
+"Last-Translator: kinichiro <kinichiro.inoguchi@gmail.com>\n"
 "Language-Team: kicad.jp <kicad@kicad.jp>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
@@ -201,7 +201,7 @@ msgstr "得られた外形はこのようなものになるかもしれません
 #. type: Plain text
 #: Pcbnew_create_and_modify_board.adoc:36
 msgid "image:images/Pcbnew_simple_board_outline.png[]"
-msgstr "image:images/ja/Pcbnew_simple_board_outline.png[]"
+msgstr "image:images/Pcbnew_simple_board_outline.png[]"
 
 #. type: Title ^
 #: Pcbnew_create_and_modify_board.adoc:38
@@ -370,7 +370,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_create_and_modify_board.adoc:92
 msgid "image:images/Pcbnew_board_outline_imported_from_a_DXF.png[]"
-msgstr "image:images/ja/Pcbnew_board_outline_imported_from_a_DXF.png[]"
+msgstr "image:images/Pcbnew_board_outline_imported_from_a_DXF.png[]"
 
 #. type: Title ^
 #: Pcbnew_create_and_modify_board.adoc:94
@@ -410,7 +410,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_create_and_modify_board.adoc:108
 msgid "image:images/Pcbnew_board_outline_with_dogpile.png[]"
-msgstr "image:images/ja/Pcbnew_board_outline_with_dogpile.png[]"
+msgstr "image:images/Pcbnew_board_outline_with_dogpile.png[]"
 
 #. type: Plain text
 #: Pcbnew_create_and_modify_board.adoc:114
@@ -430,8 +430,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_create_and_modify_board.adoc:116
 msgid "image:images/Pcbnew_board_outline_with_globally_placed_modules.png[]"
-msgstr ""
-"image:images/ja/Pcbnew_board_outline_with_globally_placed_modules.png[]"
+msgstr "image:images/Pcbnew_board_outline_with_globally_placed_modules.png[]"
 
 #. type: Plain text
 #: Pcbnew_create_and_modify_board.adoc:124
@@ -978,7 +977,7 @@ msgstr "ゾーン境界（薄い網掛けのポリゴン）の例を次に示し
 #. type: Plain text
 #: Pcbnew_zones.adoc:80
 msgid "image:images/Pcbnew_zone_limit_example.png[]"
-msgstr "image:images/ja/Pcbnew_zone_limit_example.png[]"
+msgstr "image:images/Pcbnew_zone_limit_example.png[]"
 
 #. type: Plain text
 #: Pcbnew_zones.adoc:85
@@ -1007,7 +1006,7 @@ msgstr "次に例を示します:"
 #. type: Plain text
 #: Pcbnew_zones.adoc:93
 msgid "image:images/Pcbnew_zone_priority_example.png[]"
-msgstr "image:images/ja/Pcbnew_zone_priority_example.png[]"
+msgstr "image:images/Pcbnew_zone_priority_example.png[]"
 
 #. type: Plain text
 #: Pcbnew_zones.adoc:95
@@ -1018,7 +1017,7 @@ msgstr "塗りつぶし後:"
 #. type: Plain text
 #: Pcbnew_zones.adoc:97
 msgid "image:images/Pcbnew_zone_priority_example_after_filling.png[]"
-msgstr "image:images/ja/Pcbnew_zone_priority_example_after_filling.png[]"
+msgstr "image:images/Pcbnew_zone_priority_example_after_filling.png[]"
 
 #. type: Title ^
 #: Pcbnew_zones.adoc:99
@@ -1057,7 +1056,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_zones.adoc:110
 msgid "image:images/Pcbnew_zone_filling_result.png[]"
-msgstr "image:images/ja/Pcbnew_zone_filling_result.png[]"
+msgstr "image:images/Pcbnew_zone_filling_result.png[]"
 
 #. type: Plain text
 #: Pcbnew_zones.adoc:113
@@ -1091,7 +1090,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_zones.adoc:121
 msgid "image:images/Pcbnew_zone_filled_with_cutout.png[]"
-msgstr "image:images/ja/Pcbnew_zone_filled_with_cutout.png[]"
+msgstr "image:images/Pcbnew_zone_filled_with_cutout.png[]"
 
 #. type: Title ~
 #: Pcbnew_zones.adoc:123
@@ -1203,7 +1202,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_zones.adoc:161
 msgid "image:images/Pcbnew_zone_include_pads.png[]"
-msgstr "image:images/ja/Pcbnew_zone_include_pads.png[]"
+msgstr "image:images/Pcbnew_zone_include_pads.png[]"
 
 #. type: Plain text
 #: Pcbnew_zones.adoc:165
@@ -1220,7 +1219,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_zones.adoc:167
 msgid "image:images/Pcbnew_zone_exclude_pads.png[]"
-msgstr "image:images/ja/Pcbnew_zone_exclude_pads.png[]"
+msgstr "image:images/Pcbnew_zone_exclude_pads.png[]"
 
 #. type: Plain text
 #: Pcbnew_zones.adoc:171
@@ -1236,7 +1235,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_zones.adoc:173
 msgid "image:images/Pcbnew_zone_thermal_relief.png[]"
-msgstr "image:images/ja/Pcbnew_zone_thermal_relief.png[]"
+msgstr "image:images/Pcbnew_zone_thermal_relief.png[]"
 
 #. type: Title ^
 #: Pcbnew_zones.adoc:175
@@ -1331,7 +1330,7 @@ msgstr "新規外形を作成します。"
 #. type: Plain text
 #: Pcbnew_zones.adoc:207
 msgid "image:images/Pcbnew_zone_unfilled_cutout_outline.png[]"
-msgstr "image:images/ja/Pcbnew_zone_unfilled_cutout_outline.png[]"
+msgstr "image:images/Pcbnew_zone_unfilled_cutout_outline.png[]"
 
 #. type: Title ~
 #: Pcbnew_zones.adoc:209
@@ -1387,7 +1386,7 @@ msgstr "以下は切抜きの頂点を移動した例です。"
 #. type: Plain text
 #: Pcbnew_zones.adoc:227
 msgid "image:images/Pcbnew_zone_corner_move_during.png[]"
-msgstr "image:images/ja/Pcbnew_zone_corner_move_during.png[]"
+msgstr "image:images/Pcbnew_zone_corner_move_during.png[]"
 
 #. type: Plain text
 #: Pcbnew_zones.adoc:229
@@ -1398,7 +1397,7 @@ msgstr "最終結果です:"
 #. type: Plain text
 #: Pcbnew_zones.adoc:231
 msgid "image:images/Pcbnew_zone_corner_move_after.png[]"
-msgstr "image:images/ja/Pcbnew_zone_corner_move_after.png[]"
+msgstr "image:images/Pcbnew_zone_corner_move_after.png[]"
 
 #. type: Plain text
 #: Pcbnew_zones.adoc:233
@@ -1420,7 +1419,7 @@ msgstr "同様のゾーンを追加します:"
 #. type: Plain text
 #: Pcbnew_zones.adoc:240
 msgid "image:images/Pcbnew_zone_add_similar_during.png[]"
-msgstr "image:images/ja/Pcbnew_zone_add_similar_during.png[]"
+msgstr "image:images/Pcbnew_zone_add_similar_during.png[]"
 
 #. type: Plain text
 #: Pcbnew_zones.adoc:242
@@ -1431,7 +1430,7 @@ msgstr "最終結果:"
 #. type: Plain text
 #: Pcbnew_zones.adoc:244
 msgid "image:images/Pcbnew_zone_add_similar_after.png[]"
-msgstr "image:images/ja/Pcbnew_zone_add_similar_after.png[]"
+msgstr "image:images/Pcbnew_zone_add_similar_after.png[]"
 
 #. type: Title ~
 #: Pcbnew_zones.adoc:246
@@ -1911,7 +1910,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_schematics.adoc:102
 msgid "image:images/Pcbnew_stacked_footprints.png[]"
-msgstr "image:images/ja/Pcbnew_stacked_footprints.png[]"
+msgstr "image:images/Pcbnew_stacked_footprints.png[]"
 
 #. type: Plain text
 #: Pcbnew_schematics.adoc:104
@@ -1965,7 +1964,7 @@ msgstr "次のスクリーンショットにその結果を示します。"
 #. type: Plain text
 #: Pcbnew_schematics.adoc:117
 msgid "image:images/Pcbnew_unstacked_footprints.png[]"
-msgstr "image:images/ja/Pcbnew_unstacked_footprints.png[]"
+msgstr "image:images/Pcbnew_unstacked_footprints.png[]"
 
 #. type: Title -
 #: Pcbnew_interactive_router.adoc:3
@@ -2082,8 +2081,8 @@ msgid ""
 "will turn into a cross and the tool name, will appear in the status bar."
 msgstr ""
 "ルーターツールを有効にするには、 _インタラクティブルーター_ ボタン image:"
-"images/ja/route_icon.png[Interactive Router Button] か *X* key.を押します。"
-"カーソルが十字に変わり、ツールの名前がステータスバーへ表示されます。"
+"images/route_icon.png[Interactive Router Button] か *X* key.を押します。カー"
+"ソルが十字に変わり、ツールの名前がステータスバーへ表示されます。"
 
 #. type: Plain text
 #: Pcbnew_interactive_router.adoc:49
@@ -2824,7 +2823,7 @@ msgstr "グラウンド線幅: 2.54mm(0.1インチ)。"
 #. type: Plain text
 #: Pcbnew_routing.adoc:176
 msgid "image:images/Pcbnew_dr_example_rustic.png[]"
-msgstr "image:images/ja/Pcbnew_dr_example_rustic.png[]"
+msgstr "image:images/Pcbnew_dr_example_rustic.png[]"
 
 #. type: Title ^
 #: Pcbnew_routing.adoc:178
@@ -2856,7 +2855,7 @@ msgstr "ビア: 1.27mm(0.0500インチ)。"
 #. type: Plain text
 #: Pcbnew_routing.adoc:186
 msgid "image:images/Pcbnew_dr_example_standard.png[]"
-msgstr "image:images/ja/Pcbnew_dr_example_standard.png[]"
+msgstr "image:images/Pcbnew_dr_example_standard.png[]"
 
 #. type: Title ~
 #: Pcbnew_routing.adoc:188
@@ -2960,7 +2959,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_routing.adoc:225
 msgid "image:images/Pcbnew_creating_new_track.png[]"
-msgstr "image:images/ja/Pcbnew_creating_new_track.png[]"
+msgstr "image:images/Pcbnew_creating_new_track.png[]"
 
 #. type: Plain text
 #: Pcbnew_routing.adoc:229
@@ -3213,7 +3212,7 @@ msgstr "新規配線(進行中):"
 #. type: Plain text
 #: Pcbnew_routing.adoc:319
 msgid "image:images/Pcbnew_new_track_in_progress.png[]"
-msgstr "image:images/ja/Pcbnew_new_track_in_progress.png[]"
+msgstr "image:images/Pcbnew_new_track_in_progress.png[]"
 
 #. type: Plain text
 #: Pcbnew_routing.adoc:321
@@ -3224,7 +3223,7 @@ msgstr "終了時は:"
 #. type: Plain text
 #: Pcbnew_routing.adoc:323
 msgid "image:images/Pcbnew_new_track_completed.png[]"
-msgstr "image:images/ja/Pcbnew_new_track_completed.png[]"
+msgstr "image:images/Pcbnew_new_track_completed.png[]"
 
 #. type: Plain text
 #: Pcbnew_routing.adoc:325
@@ -3366,7 +3365,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_fabrication_files.adoc:21
 msgid "image:images/Pcbnew_final_preparation_example_board.png[]"
-msgstr "image:images/ja/Pcbnew_final_preparation_example_board.png[]"
+msgstr "image:images/Pcbnew_final_preparation_example_board.png[]"
 
 # 07072015：/ja/へ変更
 #. type: Plain text
@@ -3375,8 +3374,8 @@ msgid ""
 "A color key for the 4 copper layers has also been included: image:images/"
 "Pcbnew_layer_colour_key.png[]"
 msgstr ""
-"4導体層のための主要色も含まれています: image:images/ja/"
-"Pcbnew_layer_colour_key.png[]"
+"4導体層のための主要色も含まれています: image:images/Pcbnew_layer_colour_key."
+"png[]"
 
 #. type: Title ~
 #: Pcbnew_fabrication_files.adoc:26
@@ -3444,7 +3443,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_fabrication_files.adoc:50
 msgid "image:images/Pcbnew_setting_pcb_origin.png[]"
-msgstr "image:images/ja/Pcbnew_setting_pcb_origin.png[]"
+msgstr "image:images/Pcbnew_setting_pcb_origin.png[]"
 
 #. type: Title ~
 #: Pcbnew_fabrication_files.adoc:52
@@ -4213,7 +4212,7 @@ msgstr "上部ツールバー"
 #. type: Plain text
 #: Pcbnew_managing_libs.adoc:62
 msgid "image:images/Modedit_top_toolbar.png[]"
-msgstr "image:images/ja/Modedit_top_toolbar.png[]"
+msgstr "image:images/Modedit_top_toolbar.png[]"
 
 #. type: Plain text
 #: Pcbnew_managing_libs.adoc:64
@@ -5226,7 +5225,7 @@ msgstr "*ノーマルモード* (裏面導体層アクティブ):\n"
 #. type: Plain text
 #: Pcbnew_layers.adoc:169
 msgid "image:images/Pcbnew_copper_layers_contrast_normal.png[]"
-msgstr "image:images/ja/Pcbnew_copper_layers_contrast_normal.png[]"
+msgstr "image:images/Pcbnew_copper_layers_contrast_normal.png[]"
 
 #. type: Plain text
 #: Pcbnew_layers.adoc:171
@@ -5238,7 +5237,7 @@ msgstr "*ハイコントラストモード* (裏面導体層アクティブ):\n"
 #. type: Plain text
 #: Pcbnew_layers.adoc:173
 msgid "image:images/Pcbnew_copper_layers_contrast_high.png[]"
-msgstr "image:images/ja/Pcbnew_copper_layers_contrast_high.png[]"
+msgstr "image:images/Pcbnew_copper_layers_contrast_high.png[]"
 
 #. type: Title ^
 #: Pcbnew_layers.adoc:175
@@ -5270,7 +5269,7 @@ msgstr "*ノーマルモード* (表面レジスト層アクティブ):\n"
 #. type: Plain text
 #: Pcbnew_layers.adoc:185
 msgid "image:images/Pcbnew_technical_layers_contrast_normal.png[]"
-msgstr "image:images/ja/Pcbnew_technical_layers_contrast_normal.png[]"
+msgstr "image:images/Pcbnew_technical_layers_contrast_normal.png[]"
 
 #. type: Plain text
 #: Pcbnew_layers.adoc:187
@@ -5282,7 +5281,7 @@ msgstr "*ハイコントラストモード* (表面レジスト層アクティ�
 #. type: Plain text
 #: Pcbnew_layers.adoc:188
 msgid "image:images/Pcbnew_technical_layers_contrast_high.png[]"
-msgstr "image:images/ja/Pcbnew_technical_layers_contrast_high.png[]"
+msgstr "image:images/Pcbnew_technical_layers_contrast_high.png[]"
 
 #. type: Title -
 #: Pcbnew_general_operations.adoc:3
@@ -6007,7 +6006,7 @@ msgstr "ツールメニュー"
 #. type: Plain text
 #: Pcbnew_general_operations.adoc:281
 msgid "image:images/Pcbnew_place_menu.png[]"
-msgstr "image:images/Pcbnew_place_menu.png[]"
+msgstr "image:images/ja/Pcbnew_place_menu.png[]"
 
 #. type: Title ^
 #: Pcbnew_general_operations.adoc:283
@@ -6161,7 +6160,7 @@ msgstr ""
 "    | DRC(デザインルールチェック): 配線の自動チェック。\n"
 "| image:images/ja/Pcbnew_toolbar_layer_select_dropdown.png[]\n"
 "    | ワーキングレイヤの選択。\n"
-"| image:images/ja/Pcbnew_layer_pair_indicator.png[]\n"
+"| image:images/Pcbnew_layer_pair_indicator.png[]\n"
 "    | レイヤーペアの選択(配線中にビアを打った場合の切り替え先レイヤを設定します)。\n"
 "| image:images/icons/mode_module.png[]\n"
 "    | フットプリントモード:ポップアップウインドウでモジュールオプションを有効にした場合。\n"
@@ -6218,7 +6217,7 @@ msgstr "右手側のツールバー"
 #. type: Plain text
 #: Pcbnew_general_operations.adoc:380
 msgid "image:images/Pcbnew_right_toolbar.png[float=\"right\"]"
-msgstr "image:images/ja/Pcbnew_right_toolbar.png[float=\"right\"]"
+msgstr "image:images/Pcbnew_right_toolbar.png[float=\"right\"]"
 
 #. type: Plain text
 #: Pcbnew_general_operations.adoc:383
@@ -6348,7 +6347,7 @@ msgstr "左手側のツールバー"
 #. type: Plain text
 #: Pcbnew_general_operations.adoc:440
 msgid "image:images/Pcbnew_left_toolbar.png[float=\"right\"]"
-msgstr "image:images/ja/Pcbnew_left_toolbar.png[float=\"right\"]"
+msgstr "image:images/Pcbnew_left_toolbar.png[float=\"right\"]"
 
 #. type: Plain text
 #: Pcbnew_general_operations.adoc:443
@@ -6946,7 +6945,7 @@ msgstr "x と y のオフセットを持つ 3x3 グリッド。"
 #. type: Plain text
 #: Pcbnew_editing_tools.adoc:122
 msgid "image:images/Pcbnew_array_grid_offsets.png[]"
-msgstr "image:images/ja/Pcbnew_array_grid_offsets.png[]"
+msgstr "image:images/Pcbnew_array_grid_offsets.png[]"
 
 #. type: Plain text
 #: Pcbnew_editing_tools.adoc:125
@@ -6968,7 +6967,7 @@ msgstr "行の配列シフト（間隔２）を持つ 3x3 グリッド。"
 #. type: Plain text
 #: Pcbnew_editing_tools.adoc:128
 msgid "image:images/Pcbnew_array_grid_stagger_rows_2.png[]"
-msgstr "image:images/ja/Pcbnew_array_grid_stagger_rows_2.png[]"
+msgstr "image:images/Pcbnew_array_grid_stagger_rows_2.png[]"
 
 #. type: Block title
 #: Pcbnew_editing_tools.adoc:129
@@ -6980,7 +6979,7 @@ msgstr "行の配列シフト（間隔3）を持つ 3x3 グリッド。"
 #. type: Plain text
 #: Pcbnew_editing_tools.adoc:131
 msgid "image:images/Pcbnew_array_grid_stagger_cols_3.png[]"
-msgstr "image:images/ja/Pcbnew_array_grid_stagger_cols_3.png[]"
+msgstr "image:images/Pcbnew_array_grid_stagger_cols_3.png[]"
 
 #. type: Title +
 #: Pcbnew_editing_tools.adoc:133 Pcbnew_editing_tools.adoc:184
@@ -7205,7 +7204,7 @@ msgstr "移動中にモジュールのラッツネストの表示を見ること
 #. type: Plain text
 #: Pcbnew_module_placement.adoc:25
 msgid "image:images/Pcbnew_ratsnest_during_move.png[]"
-msgstr "image:images/ja/Pcbnew_ratsnest_during_move.png[]"
+msgstr "image:images/Pcbnew_ratsnest_during_move.png[]"
 
 #. type: Plain text
 #: Pcbnew_module_placement.adoc:27
@@ -7217,7 +7216,7 @@ msgstr ""
 #. type: Plain text
 #: Pcbnew_module_placement.adoc:29
 msgid "image:images/Pcbnew_circuit_after_placement.png[]"
-msgstr "image:images/ja/Pcbnew_circuit_after_placement.png[]"
+msgstr "image:images/Pcbnew_circuit_after_placement.png[]"
 
 #. type: Title ~
 #: Pcbnew_module_placement.adoc:31


### PR DESCRIPTION
images/ja/ に向けてしまっていた画像リンクを images/ に修正しました。
出力確認して、問題ないことを確認しました。
